### PR TITLE
Condition added to prevent deactivated lines export

### DIFF
--- a/mobi.chouette.exchange.netex_stif/src/main/java/mobi/chouette/exchange/netex_stif/exporter/NetexStifLineProducerCommand.java
+++ b/mobi.chouette.exchange.netex_stif/src/main/java/mobi/chouette/exchange/netex_stif/exporter/NetexStifLineProducerCommand.java
@@ -39,6 +39,11 @@ public class NetexStifLineProducerCommand implements Command {
 			Long lineId = (Long) context.get(Constant.LINE_ID);
 			Referential r = (Referential) context.get(Constant.REFERENTIAL);
 			LineLite line = r.findLine(lineId);
+			/** If the current line is desactivated, the netex exporter should not export it**/
+			if (line.isDeactivated()) {
+				return Constant.SUCCESS;
+			}
+			
 			r.setCurrentLine(line);
 			log.info("procesing line " + NamingUtil.getName(line));
 			NetexStifExportParameters configuration = (NetexStifExportParameters) context.get(Constant.CONFIGURATION);


### PR DESCRIPTION
Fixed. Now full export won't export deactivated lines as files, and one line export will export empty dataset (only line and commun files).